### PR TITLE
create haploid subpops

### DIFF
--- a/Other_models/Bacteria_petridish_atb.slim
+++ b/Other_models/Bacteria_petridish_atb.slim
@@ -64,7 +64,7 @@ function (i)petriValues(void)
 1 early()
 {
 	// start with a small number of randomly positioned colonies, each of a single bacterium
-	sim.addSubpop("p1", N_colonies);
+	sim.addSubpop("p1", N_colonies, haploid=T);
 	p1.defineSpatialMap("petri", "xy", petriValues(), valueRange=c(0, 2), colors=c("black", "white", "#FFCCCC"));
 	for (ind in p1.individuals)
 	{

--- a/models/ConstantSize/nonWF_ConstantSize.slim
+++ b/models/ConstantSize/nonWF_ConstantSize.slim
@@ -18,13 +18,12 @@ initialize()
 	initializeGenomicElementType("g1", m1, 1.0);
 	initializeGenomicElement(g1, 0, genomeSize - 1);
 	initializeRecombinationRate(0); // In SLiM recombination is between sister chromatids
-    defineConstant("HGTrate", Rho * genomeSize); // HGT probability
-
+	defineConstant("HGTrate", Rho * genomeSize); // HGT probability
 }
 
 1 early()
 {
-	sim.addSubpop("p1", Ne);
+	sim.addSubpop("p1", Ne, haploid=T);
 	sim.rescheduleScriptBlock(s1, start=N_generations, end=N_generations);
 }
 


### PR DESCRIPTION
Fixes #1.  This PR has changes to the models needed for SLiM 3.7 compatibility.  Note that changes to the analysis code may also be needed.